### PR TITLE
fix: Set the automated release version to v0.2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,9 +6,15 @@ end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
-max_line_length = 120
+max_line_length = 80
 tab_width = 2
 trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.tf]
+max_line_length = 120
+
+[*.yaml]
+ij_yaml_indent_sequence_value = false

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "0c267cf03597d601b51af391a634a86e6714196e",
+  "initial-version": "0.2.0",
   "packages": {
     ".": {
       "changelog-sections": [


### PR DESCRIPTION
The previous configuration opened a pull request set to v0.1.0 but that version already exists, this hopefully configures release-please to correctly set the initial version to v0.2.0.