### PR TITLE
fix: Use BucketOwnerPreferred instead of Enforced

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ automatic SSL/TLS certificates, HTTP/3, IPv6, and secure defaults using
 ```terraform
 module "website" {
   source  = "unfunco/static-website/aws"
-  version = "0.1.0"
+  version = "0.2.0"
 
   domain_name = "unfun.co"
 }

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_s3_bucket_ownership_controls" "logs" {
   bucket = aws_s3_bucket.logs[0].id
 
   rule {
-    object_ownership = "BucketOwnerEnforced"
+    object_ownership = "BucketOwnerPreferred"
   }
 }
 


### PR DESCRIPTION
Resolves an issue with the module being unable to create the log bucket since CloudFront would not have been able to write to it.