### PR TITLE
feat: Add default index and error documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,29 @@ module "website" {
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block)         | resource    |
 | [aws_s3_bucket_versioning.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning)                           | resource    |
 | [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning)                           | resource    |
+| [aws_s3_object.error_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object)                                       | resource    |
+| [aws_s3_object.index_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object)                                       | resource    |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                          | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition)                                              | data source |
 
 ### Inputs
 
-| Name                           | Description                                               | Type          | Default        | Required |
-| ------------------------------ | --------------------------------------------------------- | ------------- | -------------- | :------: |
-| bucket_name                    | Name of the S3 bucket that will store the website.        | `string`      | `""`           |    no    |
-| bucket_name_logs               | Name of the S3 bucket that will store logs.               | `string`      | `""`           |    no    |
-| create                         | Enable/disable the creation of all resources.             | `bool`        | `true`         |    no    |
-| create_certificate             | Enable/disable the creation of an ACM certificate.        | `bool`        | `true`         |    no    |
-| create_cloudfront_distribution | Enable/disable the creation of a CloudFront distribution. | `bool`        | `true`         |    no    |
-| create_log_bucket              | Enable/disable the creation of a log bucket.              | `bool`        | `true`         |    no    |
-| domain_name                    | Domain name of the website.                               | `string`      | n/a            |   yes    |
-| enable_logging                 | Enable/disable logging on the S3 bucket.                  | `bool`        | `true`         |    no    |
-| enable_versioning              | Enable/disable versioning on the S3 bucket.               | `bool`        | `true`         |    no    |
-| error_document                 | Document returned when a 4xx error occurs.                | `string`      | `"error.html"` |    no    |
-| index_document                 | Document returned for directory requests.                 | `string`      | `"index.html"` |    no    |
-| tags                           | Tags to apply to all applicable resources.                | `map(string)` | `{}`           |    no    |
+| Name                                | Description                                               | Type          | Default            | Required |
+| ----------------------------------- | --------------------------------------------------------- | ------------- | ------------------ | :------: |
+| bucket_name                         | Name of the S3 bucket that will store the website.        | `string`      | `""`               |    no    |
+| bucket_name_logs                    | Name of the S3 bucket that will store logs.               | `string`      | `""`               |    no    |
+| cloudfront_distribution_price_class | Price class for the CloudFront distribution.              | `string`      | `"PriceClass_All"` |    no    |
+| create                              | Enable/disable the creation of all resources.             | `bool`        | `true`             |    no    |
+| create_certificate                  | Enable/disable the creation of an ACM certificate.        | `bool`        | `true`             |    no    |
+| create_cloudfront_distribution      | Enable/disable the creation of a CloudFront distribution. | `bool`        | `true`             |    no    |
+| create_default_documents            | Enable/disable the creation of a default index document.  | `bool`        | `true`             |    no    |
+| create_log_bucket                   | Enable/disable the creation of a log bucket.              | `bool`        | `true`             |    no    |
+| domain_name                         | Domain name of the website.                               | `string`      | n/a                |   yes    |
+| enable_logging                      | Enable/disable logging on the S3 bucket.                  | `bool`        | `true`             |    no    |
+| enable_versioning                   | Enable/disable versioning on the S3 bucket.               | `bool`        | `true`             |    no    |
+| error_document                      | Document returned when a 4xx error occurs.                | `string`      | `"error.html"`     |    no    |
+| index_document                      | Document returned for directory requests.                 | `string`      | `"index.html"`     |    no    |
+| tags                                | Tags to apply to all applicable resources.                | `map(string)` | `{}`               |    no    |
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,58 @@ resource "aws_s3_bucket_versioning" "this" {
   }
 }
 
+resource "aws_s3_object" "error_document" {
+  count = var.create && var.create_default_documents ? 1 : 0
+
+  bucket       = aws_s3_bucket.this[0].id
+  content_type = "text/html"
+  key          = var.error_document
+
+  content = <<-EOF
+    <!DOCTYPE html>
+    <html dir="ltr" lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="initial-scale=1.0,width=device-width">
+      <title>Whoops</title>
+    </head>
+    <body>
+      <p>An error occurred.</p>
+    </body>
+    </html>
+  EOF
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "aws_s3_object" "index_document" {
+  count = var.create && var.create_default_documents ? 1 : 0
+
+  bucket       = aws_s3_bucket.this[0].id
+  content_type = "text/html"
+  key          = var.index_document
+
+  content = <<-EOF
+    <!DOCTYPE html>
+    <html dir="ltr" lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="initial-scale=1.0,width=device-width">
+      <title>Booyah achieved!</title>
+    </head>
+    <body>
+      <p>Your static website has been successfully created!</p>
+    </body>
+    </html>
+  EOF
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
 resource "aws_s3_bucket" "logs" {
   count = var.create && var.enable_logging && var.create_log_bucket ? 1 : 0
 
@@ -144,7 +196,7 @@ resource "aws_cloudfront_distribution" "this" {
   enabled             = true
   http_version        = "http2and3"
   is_ipv6_enabled     = true
-  price_class         = "PriceClass_All"
+  price_class         = var.cloudfront_distribution_price_class
   provider            = aws.us_east_1
   retain_on_delete    = true
   tags                = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "bucket_name_logs" {
   type        = string
 }
 
+variable "cloudfront_distribution_price_class" {
+  default     = "PriceClass_All"
+  description = "Price class for the CloudFront distribution."
+  type        = string
+}
+
 variable "create" {
   default     = true
   description = "Enable/disable the creation of all resources."
@@ -28,6 +34,12 @@ variable "create_certificate" {
 variable "create_cloudfront_distribution" {
   default     = true
   description = "Enable/disable the creation of a CloudFront distribution."
+  type        = bool
+}
+
+variable "create_default_documents" {
+  default     = true
+  description = "Enable/disable the creation of a default index document."
   type        = bool
 }
 


### PR DESCRIPTION
When the module is applied for the first time, it would display an access denied error since the S3 bucket was empty, this creates the default index and error documents with some sample content that's intended to be replaced, replacing those files in S3 will not cause issues when reapplying this module.

Additionally, this commit allows the price class for the CloudFront distribution to be set.