### PR TITLE
fix: Allow custom CloudFront distribution ARNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,23 @@ module "website" {
 
 ### Inputs
 
-| Name                                | Description                                               | Type          | Default            | Required |
-| ----------------------------------- | --------------------------------------------------------- | ------------- | ------------------ | :------: |
-| bucket_name                         | Name of the S3 bucket that will store the website.        | `string`      | `""`               |    no    |
-| bucket_name_logs                    | Name of the S3 bucket that will store logs.               | `string`      | `""`               |    no    |
-| cloudfront_distribution_price_class | Price class for the CloudFront distribution.              | `string`      | `"PriceClass_All"` |    no    |
-| create                              | Enable/disable the creation of all resources.             | `bool`        | `true`             |    no    |
-| create_certificate                  | Enable/disable the creation of an ACM certificate.        | `bool`        | `true`             |    no    |
-| create_cloudfront_distribution      | Enable/disable the creation of a CloudFront distribution. | `bool`        | `true`             |    no    |
-| create_default_documents            | Enable/disable the creation of a default index document.  | `bool`        | `true`             |    no    |
-| create_log_bucket                   | Enable/disable the creation of a log bucket.              | `bool`        | `true`             |    no    |
-| domain_name                         | Domain name of the website.                               | `string`      | n/a                |   yes    |
-| enable_logging                      | Enable/disable logging on the S3 bucket.                  | `bool`        | `true`             |    no    |
-| enable_versioning                   | Enable/disable versioning on the S3 bucket.               | `bool`        | `true`             |    no    |
-| error_document                      | Document returned when a 4xx error occurs.                | `string`      | `"error.html"`     |    no    |
-| index_document                      | Document returned for directory requests.                 | `string`      | `"index.html"`     |    no    |
-| tags                                | Tags to apply to all applicable resources.                | `map(string)` | `{}`               |    no    |
+| Name                                | Description                                                                      | Type          | Default            | Required |
+| ----------------------------------- | -------------------------------------------------------------------------------- | ------------- | ------------------ | :------: |
+| bucket_name                         | Name of the S3 bucket that will store the website.                               | `string`      | `""`               |    no    |
+| bucket_name_logs                    | Name of the S3 bucket that will store logs.                                      | `string`      | `""`               |    no    |
+| cloudfront_distribution_arn         | ARN of an existing CloudFront distribution to use instead of creating a new one. | `string`      | `""`               |    no    |
+| cloudfront_distribution_price_class | Price class for the CloudFront distribution.                                     | `string`      | `"PriceClass_All"` |    no    |
+| create                              | Enable/disable the creation of all resources.                                    | `bool`        | `true`             |    no    |
+| create_certificate                  | Enable/disable the creation of an ACM certificate.                               | `bool`        | `true`             |    no    |
+| create_cloudfront_distribution      | Enable/disable the creation of a CloudFront distribution.                        | `bool`        | `true`             |    no    |
+| create_default_documents            | Enable/disable the creation of a default index document.                         | `bool`        | `true`             |    no    |
+| create_log_bucket                   | Enable/disable the creation of a log bucket.                                     | `bool`        | `true`             |    no    |
+| domain_name                         | Domain name of the website.                                                      | `string`      | n/a                |   yes    |
+| enable_logging                      | Enable/disable logging on the S3 bucket.                                         | `bool`        | `true`             |    no    |
+| enable_versioning                   | Enable/disable versioning on the S3 bucket.                                      | `bool`        | `true`             |    no    |
+| error_document                      | Document returned when a 4xx error occurs.                                       | `string`      | `"error.html"`     |    no    |
+| index_document                      | Document returned for directory requests.                                        | `string`      | `"index.html"`     |    no    |
+| tags                                | Tags to apply to all applicable resources.                                       | `map(string)` | `{}`               |    no    |
 
 ### Outputs
 

--- a/data.tf
+++ b/data.tf
@@ -6,7 +6,7 @@ data "aws_partition" "this" {
 }
 
 data "aws_iam_policy_document" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && (var.create_cloudfront_distribution || var.cloudfront_distribution_arn != "") ? 1 : 0
 
   statement {
     actions = ["s3:GetObject"]
@@ -22,11 +22,11 @@ data "aws_iam_policy_document" "this" {
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
-      values   = [aws_cloudfront_distribution.this[0].arn]
+      values   = [try(aws_cloudfront_distribution.this[0].arn, var.cloudfront_distribution_arn)]
     }
 
     principals {
-      identifiers = ["cloudfront.amazonaws.com"]
+      identifiers = ["cloudfront.${data.aws_partition.this[0].dns_suffix}"]
       type        = "Service"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "bucket_name_logs" {
   type        = string
 }
 
+variable "cloudfront_distribution_arn" {
+  default     = ""
+  description = "ARN of an existing CloudFront distribution to use instead of creating a new one."
+  type        = string
+}
+
 variable "cloudfront_distribution_price_class" {
   default     = "PriceClass_All"
   description = "Price class for the CloudFront distribution."


### PR DESCRIPTION
There is a variable that disables the creation of CloudFront distributions, when this was set to false, the IAM policy was still attempting to reference the ARN in order to allow the distribution to fetch objects from the S3 bucket, this adds a new variable that allows a custom CloudFront distribution ARN to be given permission to access the S3 bucket instead.