### PR TITLE
feat: Allow custom log bucket target prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ module "website" {
 | enable_versioning                   | Enable/disable versioning on the S3 bucket.                                      | `bool`        | `true`             |    no    |
 | error_document                      | Document returned when a 4xx error occurs.                                       | `string`      | `"error.html"`     |    no    |
 | index_document                      | Document returned for directory requests.                                        | `string`      | `"index.html"`     |    no    |
+| log_bucket_target_prefix            | Prefix for log files in the logging bucket.                                      | `string`      | `""`               |    no    |
 | tags                                | Tags to apply to all applicable resources.                                       | `map(string)` | `{}`               |    no    |
 
 ### Outputs

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 locals {
-  bucket_name = var.bucket_name == "" ? local.domain_name : var.bucket_name
-  domain_name = lower(var.domain_name)
+  bucket_name              = var.bucket_name == "" ? local.domain_name : var.bucket_name
+  domain_name              = lower(var.domain_name)
+  log_bucket_target_prefix = var.log_bucket_target_prefix == "" ? local.bucket_name : var.log_bucket_target_prefix
 }
 
 resource "aws_acm_certificate" "this" {
@@ -52,7 +53,7 @@ resource "aws_s3_bucket_logging" "this" {
 
   bucket        = aws_s3_bucket.this[0].id
   target_bucket = var.bucket_name_logs == "" ? aws_s3_bucket.logs[0].id : var.bucket_name_logs
-  target_prefix = "s3/"
+  target_prefix = "${local.log_bucket_target_prefix}/s3/"
 }
 
 resource "aws_s3_bucket_policy" "this" {
@@ -230,7 +231,7 @@ resource "aws_cloudfront_distribution" "this" {
 
     content {
       bucket = aws_s3_bucket.logs[0].bucket_regional_domain_name
-      prefix = "cloudfront/"
+      prefix = "${local.log_bucket_target_prefix}/cloudfront/"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "index_document" {
   type        = string
 }
 
+variable "log_bucket_target_prefix" {
+  default     = ""
+  description = "Prefix for log files in the logging bucket."
+  type        = string
+}
+
 variable "tags" {
   default     = {}
   description = "Tags to apply to all applicable resources."


### PR DESCRIPTION
In scenarios where this module is being called multiple times, it was not previously possible to separate the logs from different S3 buckets, this allows the target prefix to be configured, allowing separate static websites to share a single log bucket, but have their logs segregated by prefix/directory.