### PR TITLE
feat: Allow the ACM certificate ARN to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,24 +48,25 @@ module "website" {
 
 ### Inputs
 
-| Name                                | Description                                                                      | Type          | Default            | Required |
-| ----------------------------------- | -------------------------------------------------------------------------------- | ------------- | ------------------ | :------: |
-| bucket_name                         | Name of the S3 bucket that will store the website.                               | `string`      | `""`               |    no    |
-| bucket_name_logs                    | Name of the S3 bucket that will store logs.                                      | `string`      | `""`               |    no    |
-| cloudfront_distribution_arn         | ARN of an existing CloudFront distribution to use instead of creating a new one. | `string`      | `""`               |    no    |
-| cloudfront_distribution_price_class | Price class for the CloudFront distribution.                                     | `string`      | `"PriceClass_All"` |    no    |
-| create                              | Enable/disable the creation of all resources.                                    | `bool`        | `true`             |    no    |
-| create_certificate                  | Enable/disable the creation of an ACM certificate.                               | `bool`        | `true`             |    no    |
-| create_cloudfront_distribution      | Enable/disable the creation of a CloudFront distribution.                        | `bool`        | `true`             |    no    |
-| create_default_documents            | Enable/disable the creation of a default index document.                         | `bool`        | `true`             |    no    |
-| create_log_bucket                   | Enable/disable the creation of a log bucket.                                     | `bool`        | `true`             |    no    |
-| domain_name                         | Domain name of the website.                                                      | `string`      | n/a                |   yes    |
-| enable_logging                      | Enable/disable logging on the S3 bucket.                                         | `bool`        | `true`             |    no    |
-| enable_versioning                   | Enable/disable versioning on the S3 bucket.                                      | `bool`        | `true`             |    no    |
-| error_document                      | Document returned when a 4xx error occurs.                                       | `string`      | `"error.html"`     |    no    |
-| index_document                      | Document returned for directory requests.                                        | `string`      | `"index.html"`     |    no    |
-| log_bucket_target_prefix            | Prefix for log files in the logging bucket.                                      | `string`      | `""`               |    no    |
-| tags                                | Tags to apply to all applicable resources.                                       | `map(string)` | `{}`               |    no    |
+| Name                                | Description                                                                                                               | Type          | Default            | Required |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------ | :------: |
+| acm_certificate_arn                 | The ARN of an existing ACM certificate to use for the CloudFront distribution. Required when create_certificate is false. | `string`      | `""`               |    no    |
+| bucket_name                         | The name of the S3 bucket for storing website content.                                                                    | `string`      | `""`               |    no    |
+| cloudfront_distribution_arn         | The ARN of an existing CloudFront distribution to use for the S3 bucket policy.                                           | `string`      | `""`               |    no    |
+| cloudfront_distribution_price_class | The price class for the CloudFront distribution.                                                                          | `string`      | `"PriceClass_All"` |    no    |
+| create                              | Whether to create resources.                                                                                              | `bool`        | `true`             |    no    |
+| create_certificate                  | Whether to create an ACM certificate.                                                                                     | `bool`        | `true`             |    no    |
+| create_cloudfront_distribution      | Whether to create a CloudFront distribution.                                                                              | `bool`        | `true`             |    no    |
+| create_default_documents            | Whether to create default index and error documents.                                                                      | `bool`        | `true`             |    no    |
+| create_log_bucket                   | Whether to create a dedicated logging bucket.                                                                             | `bool`        | `true`             |    no    |
+| domain_name                         | The domain name for the website.                                                                                          | `string`      | n/a                |   yes    |
+| enable_logging                      | Whether to enable access logging for S3 and CloudFront.                                                                   | `bool`        | `true`             |    no    |
+| enable_versioning                   | Whether to enable versioning on the S3 bucket.                                                                            | `bool`        | `true`             |    no    |
+| error_document                      | The path to the error document returned for 4xx errors.                                                                   | `string`      | `"error.html"`     |    no    |
+| index_document                      | The path to the index document returned for directory requests.                                                           | `string`      | `"index.html"`     |    no    |
+| log_bucket_name                     | The name of the S3 bucket for storing access logs.                                                                        | `string`      | `""`               |    no    |
+| log_bucket_target_prefix            | The prefix for log objects in the logging bucket.                                                                         | `string`      | `""`               |    no    |
+| tags                                | The tags to apply to all taggable resources.                                                                              | `map(string)` | `{}`               |    no    |
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_s3_bucket_logging" "this" {
   count = var.create && var.enable_logging ? 1 : 0
 
   bucket        = aws_s3_bucket.this[0].id
-  target_bucket = var.bucket_name_logs == "" ? aws_s3_bucket.logs[0].id : var.bucket_name_logs
+  target_bucket = var.log_bucket_name == "" ? aws_s3_bucket.logs[0].id : var.log_bucket_name
   target_prefix = "${local.log_bucket_target_prefix}/s3/"
 }
 
@@ -128,7 +128,7 @@ resource "aws_s3_object" "index_document" {
 resource "aws_s3_bucket" "logs" {
   count = var.create && var.enable_logging && var.create_log_bucket ? 1 : 0
 
-  bucket        = var.bucket_name_logs == "" ? join("-", [aws_s3_bucket.this[0].id, "logs"]) : var.bucket_name_logs
+  bucket        = var.log_bucket_name == "" ? join("-", [aws_s3_bucket.this[0].id, "logs"]) : var.log_bucket_name
   force_destroy = true
   tags          = var.tags
 }
@@ -248,7 +248,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   viewer_certificate {
-    acm_certificate_arn            = aws_acm_certificate.this[0].arn
+    acm_certificate_arn            = var.create_certificate ? aws_acm_certificate.this[0].arn : var.acm_certificate_arn
     cloudfront_default_certificate = !var.create_certificate
     minimum_protocol_version       = "TLSv1.2_2021"
     ssl_support_method             = "sni-only"

--- a/variables.tf
+++ b/variables.tf
@@ -3,95 +3,101 @@
 
 variable "bucket_name" {
   default     = ""
-  description = "Name of the S3 bucket that will store the website."
+  description = "The name of the S3 bucket for storing website content."
   type        = string
 }
 
-variable "bucket_name_logs" {
+variable "log_bucket_name" {
   default     = ""
-  description = "Name of the S3 bucket that will store logs."
+  description = "The name of the S3 bucket for storing access logs."
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  default     = ""
+  description = "The ARN of an existing ACM certificate to use for the CloudFront distribution. Required when create_certificate is false."
   type        = string
 }
 
 variable "cloudfront_distribution_arn" {
   default     = ""
-  description = "ARN of an existing CloudFront distribution to use instead of creating a new one."
+  description = "The ARN of an existing CloudFront distribution to use for the S3 bucket policy."
   type        = string
 }
 
 variable "cloudfront_distribution_price_class" {
   default     = "PriceClass_All"
-  description = "Price class for the CloudFront distribution."
+  description = "The price class for the CloudFront distribution."
   type        = string
 }
 
 variable "create" {
   default     = true
-  description = "Enable/disable the creation of all resources."
+  description = "Whether to create resources."
   type        = bool
 }
 
 variable "create_certificate" {
   default     = true
-  description = "Enable/disable the creation of an ACM certificate."
+  description = "Whether to create an ACM certificate."
   type        = bool
 }
 
 variable "create_cloudfront_distribution" {
   default     = true
-  description = "Enable/disable the creation of a CloudFront distribution."
+  description = "Whether to create a CloudFront distribution."
   type        = bool
 }
 
 variable "create_default_documents" {
   default     = true
-  description = "Enable/disable the creation of a default index document."
+  description = "Whether to create default index and error documents."
   type        = bool
 }
 
 variable "create_log_bucket" {
   default     = true
-  description = "Enable/disable the creation of a log bucket."
+  description = "Whether to create a dedicated logging bucket."
   type        = bool
 }
 
 variable "domain_name" {
-  description = "Domain name of the website."
+  description = "The domain name for the website."
   type        = string
 }
 
 variable "enable_logging" {
   default     = true
-  description = "Enable/disable logging on the S3 bucket."
+  description = "Whether to enable access logging for S3 and CloudFront."
   type        = bool
 }
 
 variable "enable_versioning" {
   default     = true
-  description = "Enable/disable versioning on the S3 bucket."
+  description = "Whether to enable versioning on the S3 bucket."
   type        = bool
 }
 
 variable "error_document" {
   default     = "error.html"
-  description = "Document returned when a 4xx error occurs."
+  description = "The path to the error document returned for 4xx errors."
   type        = string
 }
 
 variable "index_document" {
   default     = "index.html"
-  description = "Document returned for directory requests."
+  description = "The path to the index document returned for directory requests."
   type        = string
 }
 
 variable "log_bucket_target_prefix" {
   default     = ""
-  description = "Prefix for log files in the logging bucket."
+  description = "The prefix for log objects in the logging bucket."
   type        = string
 }
 
 variable "tags" {
   default     = {}
-  description = "Tags to apply to all applicable resources."
+  description = "The tags to apply to all taggable resources."
   type        = map(string)
 }


### PR DESCRIPTION
This allows the certificate ARN to be configured, so that when the create_certificate variable is set to false, it will not error when it attempts to retrieve the ID of a non-existent certificate.