### PR TITLE
feat: Add a force_destroy variable for S3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ module "website" {
 | enable_logging                      | Whether to enable access logging for S3 and CloudFront.                                                                   | `bool`        | `true`             |    no    |
 | enable_versioning                   | Whether to enable versioning on the S3 bucket.                                                                            | `bool`        | `true`             |    no    |
 | error_document                      | The path to the error document returned for 4xx errors.                                                                   | `string`      | `"error.html"`     |    no    |
+| force_destroy                       | Whether to allow bucket deletion even when not empty.                                                                     | `bool`        | `false`            |    no    |
 | index_document                      | The path to the index document returned for directory requests.                                                           | `string`      | `"index.html"`     |    no    |
 | log_bucket_name                     | The name of the S3 bucket for storing access logs.                                                                        | `string`      | `""`               |    no    |
 | log_bucket_target_prefix            | The prefix for log objects in the logging bucket.                                                                         | `string`      | `""`               |    no    |

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket" "this" {
   count = var.create ? 1 : 0
 
   bucket        = var.bucket_name == "" ? local.domain_name : var.bucket_name
-  force_destroy = true
+  force_destroy = var.force_destroy
   tags          = var.tags
 }
 
@@ -132,7 +132,7 @@ resource "aws_s3_bucket" "logs" {
   count = var.create && var.enable_logging && var.create_log_bucket ? 1 : 0
 
   bucket        = var.log_bucket_name == "" ? join("-", [aws_s3_bucket.this[0].id, "logs"]) : var.log_bucket_name
-  force_destroy = true
+  force_destroy = var.force_destroy
   tags          = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,12 @@ variable "error_document" {
   type        = string
 }
 
+variable "force_destroy" {
+  default     = false
+  description = "Whether to allow bucket deletion even when not empty."
+  type        = bool
+}
+
 variable "index_document" {
   default     = "index.html"
   description = "The path to the index document returned for directory requests."


### PR DESCRIPTION
This adds a force_destroy variable that will apply to both the website bucket and the logs bucket.