### PR TITLE
feat: Make more of CloudFront configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,26 +48,30 @@ module "website" {
 
 ### Inputs
 
-| Name                                | Description                                                                                                               | Type          | Default            | Required |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------ | :------: |
-| acm_certificate_arn                 | The ARN of an existing ACM certificate to use for the CloudFront distribution. Required when create_certificate is false. | `string`      | `""`               |    no    |
-| bucket_name                         | The name of the S3 bucket for storing website content.                                                                    | `string`      | `""`               |    no    |
-| cloudfront_distribution_arn         | The ARN of an existing CloudFront distribution to use for the S3 bucket policy.                                           | `string`      | `""`               |    no    |
-| cloudfront_distribution_price_class | The price class for the CloudFront distribution.                                                                          | `string`      | `"PriceClass_All"` |    no    |
-| create                              | Whether to create resources.                                                                                              | `bool`        | `true`             |    no    |
-| create_certificate                  | Whether to create an ACM certificate.                                                                                     | `bool`        | `true`             |    no    |
-| create_cloudfront_distribution      | Whether to create a CloudFront distribution.                                                                              | `bool`        | `true`             |    no    |
-| create_default_documents            | Whether to create default index and error documents.                                                                      | `bool`        | `true`             |    no    |
-| create_log_bucket                   | Whether to create a dedicated logging bucket.                                                                             | `bool`        | `true`             |    no    |
-| domain_name                         | The domain name for the website.                                                                                          | `string`      | n/a                |   yes    |
-| enable_logging                      | Whether to enable access logging for S3 and CloudFront.                                                                   | `bool`        | `true`             |    no    |
-| enable_versioning                   | Whether to enable versioning on the S3 bucket.                                                                            | `bool`        | `true`             |    no    |
-| error_document                      | The path to the error document returned for 4xx errors.                                                                   | `string`      | `"error.html"`     |    no    |
-| force_destroy                       | Whether to allow bucket deletion even when not empty.                                                                     | `bool`        | `false`            |    no    |
-| index_document                      | The path to the index document returned for directory requests.                                                           | `string`      | `"index.html"`     |    no    |
-| log_bucket_name                     | The name of the S3 bucket for storing access logs.                                                                        | `string`      | `""`               |    no    |
-| log_bucket_target_prefix            | The prefix for log objects in the logging bucket.                                                                         | `string`      | `""`               |    no    |
-| tags                                | The tags to apply to all taggable resources.                                                                              | `map(string)` | `{}`               |    no    |
+| Name                                  | Description                                                                                                               | Type           | Default             | Required |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------------- | :------: |
+| acm_certificate_arn                   | The ARN of an existing ACM certificate to use for the CloudFront distribution. Required when create_certificate is false. | `string`       | `""`                |    no    |
+| bucket_name                           | The name of the S3 bucket for storing website content.                                                                    | `string`       | `""`                |    no    |
+| cloudfront_allowed_methods            | The HTTP methods allowed by the CloudFront distribution.                                                                  | `list(string)` | `[ "GET", "HEAD" ]` |    no    |
+| cloudfront_distribution_arn           | The ARN of an existing CloudFront distribution to use for the S3 bucket policy.                                           | `string`       | `""`                |    no    |
+| cloudfront_distribution_price_class   | The price class for the CloudFront distribution.                                                                          | `string`       | `"PriceClass_All"`  |    no    |
+| cloudfront_response_headers_policy_id | The ID of a response headers policy to attach to the CloudFront distribution.                                             | `string`       | `null`              |    no    |
+| cloudfront_retain_on_delete           | Whether to retain the CloudFront distribution when deleting the resource.                                                 | `bool`         | `false`             |    no    |
+| cloudfront_web_acl_id                 | The ID of a WAF web ACL to associate with the CloudFront distribution.                                                    | `string`       | `null`              |    no    |
+| create                                | Whether to create resources.                                                                                              | `bool`         | `true`              |    no    |
+| create_certificate                    | Whether to create an ACM certificate.                                                                                     | `bool`         | `true`              |    no    |
+| create_cloudfront_distribution        | Whether to create a CloudFront distribution.                                                                              | `bool`         | `true`              |    no    |
+| create_default_documents              | Whether to create default index and error documents.                                                                      | `bool`         | `true`              |    no    |
+| create_log_bucket                     | Whether to create a dedicated logging bucket.                                                                             | `bool`         | `true`              |    no    |
+| domain_name                           | The domain name for the website.                                                                                          | `string`       | n/a                 |   yes    |
+| enable_logging                        | Whether to enable access logging for S3 and CloudFront.                                                                   | `bool`         | `true`              |    no    |
+| enable_versioning                     | Whether to enable versioning on the S3 bucket.                                                                            | `bool`         | `true`              |    no    |
+| error_document                        | The path to the error document returned for 4xx errors.                                                                   | `string`       | `"error.html"`      |    no    |
+| force_destroy                         | Whether to allow bucket deletion even when not empty.                                                                     | `bool`         | `false`             |    no    |
+| index_document                        | The path to the index document returned for directory requests.                                                           | `string`       | `"index.html"`      |    no    |
+| log_bucket_name                       | The name of the S3 bucket for storing access logs.                                                                        | `string`       | `""`                |    no    |
+| log_bucket_target_prefix              | The prefix for log objects in the logging bucket.                                                                         | `string`       | `""`                |    no    |
+| tags                                  | The tags to apply to all taggable resources.                                                                              | `map(string)`  | `{}`                |    no    |
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -202,9 +202,10 @@ resource "aws_cloudfront_distribution" "this" {
   is_ipv6_enabled     = true
   price_class         = var.cloudfront_distribution_price_class
   provider            = aws.us_east_1
-  retain_on_delete    = true
+  retain_on_delete    = var.cloudfront_retain_on_delete
   tags                = var.tags
   wait_for_deployment = true
+  web_acl_id          = var.cloudfront_web_acl_id
 
   custom_error_response {
     error_caching_min_ttl = 10
@@ -221,12 +222,13 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   default_cache_behavior {
-    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-    cache_policy_id        = "658327ea-f89d-4fab-a63d-7e88639e58f6" # Managed-CachingOptimized
-    cached_methods         = ["GET", "HEAD"]
-    compress               = true
-    target_origin_id       = aws_s3_bucket.this[0].id
-    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods            = var.cloudfront_allowed_methods
+    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6" # Managed-CachingOptimized
+    cached_methods             = ["GET", "HEAD"]
+    compress                   = true
+    response_headers_policy_id = var.cloudfront_response_headers_policy_id
+    target_origin_id           = aws_s3_bucket.this[0].id
+    viewer_protocol_policy     = "redirect-to-https"
   }
 
   dynamic "logging_config" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,9 +19,33 @@ variable "cloudfront_distribution_arn" {
   type        = string
 }
 
+variable "cloudfront_allowed_methods" {
+  default     = ["GET", "HEAD"]
+  description = "The HTTP methods allowed by the CloudFront distribution."
+  type        = list(string)
+}
+
 variable "cloudfront_distribution_price_class" {
   default     = "PriceClass_All"
   description = "The price class for the CloudFront distribution."
+  type        = string
+}
+
+variable "cloudfront_response_headers_policy_id" {
+  default     = null
+  description = "The ID of a response headers policy to attach to the CloudFront distribution."
+  type        = string
+}
+
+variable "cloudfront_retain_on_delete" {
+  default     = false
+  description = "Whether to retain the CloudFront distribution when deleting the resource."
+  type        = bool
+}
+
+variable "cloudfront_web_acl_id" {
+  default     = null
+  description = "The ID of a WAF web ACL to associate with the CloudFront distribution."
   type        = string
 }
 


### PR DESCRIPTION
This allows the allowed methods, response headers, retention following deletion, and WAF ACL to be configured.