### PR TITLE
fix: Update version numbers in the README

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -25,7 +25,6 @@
       "extra-files": [
         {
           "path": "README.md",
-          "regex": "version\\s*=\\s*\"(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\"",
           "type": "generic"
         }
       ],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Push
+name: CI
 
 on:
   push:
@@ -38,4 +38,3 @@ jobs:
       with:
         config-file: .github/release-please-config.json
         manifest-file: .github/release-please-manifest.json
-        token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ automatic SSL/TLS certificates, HTTP/3, IPv6, and secure defaults using
 
 ### Installation and usage
 
+<!-- x-release-please-start-version -->
 ```terraform
 module "website" {
   source  = "unfunco/static-website/aws"
@@ -20,6 +21,7 @@ module "website" {
   domain_name = "unfun.co"
 }
 ```
+<!-- x-release-please-end -->
 
 <!-- BEGIN_TF_DOCS -->
 


### PR DESCRIPTION
This adds invisible comments to the README that should provide a hint to Release Please as to where it should update the version number for the next release.