### PR TITLE
feat: Add an IAM policy for CI pipelines

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -26,6 +26,10 @@
         {
           "path": "README.md",
           "type": "generic"
+        },
+        {
+          "path": "modules/ci-iam-policy/README.md",
+          "type": "generic"
         }
       ],
       "extra-label": "automata 🤖,autorelease: pending,chore 🧹",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   verify:
-    name: Verify
+    name: Verify (${{ matrix.directory }})
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout code
@@ -22,6 +22,15 @@ jobs:
       run: terraform fmt -check -recursive
     - name: Validate the configuration
       run: terraform validate
+    strategy:
+      fail-fast: false
+      matrix:
+        directory:
+        - .
+        - modules/ci-iam-policy
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
 
   release:
     name: Release?

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   verify:
-    name: Verify
+    name: Verify (${{ matrix.directory }})
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout code
@@ -22,3 +22,12 @@ jobs:
       run: terraform fmt -check -recursive
     - name: Validate the configuration
       run: terraform validate
+    strategy:
+      fail-fast: false
+      matrix:
+        directory:
+        - .
+        - modules/ci-iam-policy
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ automatic SSL/TLS certificates, HTTP/3, IPv6, and secure defaults using
 ### Installation and usage
 
 <!-- x-release-please-start-version -->
+
 ```terraform
 module "website" {
   source  = "unfunco/static-website/aws"
@@ -25,7 +26,34 @@ module "website" {
   domain_name = "unfun.co"
 }
 ```
+
+#### IAM
+
+```terraform
+module "ci_iam_policy_deploy" {
+  source  = "unfunco/static-website/aws//modules/ci-iam-policy"
+  version = "0.3.0"
+
+  attach_content_permissions  = true
+  bucket_name                 = module.website.bucket_name
+  cloudfront_distribution_arn = module.website.cloudfront_distribution_arn
+}
+```
+
 <!-- x-release-please-end -->
+
+```terraform
+module "oidc_github" {
+  source  = "unfunco/oidc-github/aws"
+  version = "2.0.2"
+
+  github_repositories = ["unfunco/unfun.co"]
+
+  iam_role_inline_policies = {
+    deploy = module.ci_iam_policy_deploy.policy_document
+  }
+}
+```
 
 <!-- BEGIN_TF_DOCS -->
 
@@ -85,8 +113,10 @@ module "website" {
 | ------------------------------------- | ----------------------------------------------------- |
 | bucket_arn                            | The ARN of the S3 bucket.                             |
 | bucket_id                             | The ID of the S3 bucket.                              |
+| bucket_name                           | The name of the S3 bucket.                            |
 | certificate_arn                       | The ARN of the ACM certificate.                       |
 | certificate_domain_validation_options | The domain validation options of the ACM certificate. |
+| cloudfront_distribution_arn           | The ARN of the CloudFront distribution.               |
 | cloudfront_distribution_id            | The CloudFront distribution ID.                       |
 | cloudfront_domain_name                | The CloudFront domain name.                           |
 | cloudfront_hosted_zone_id             | The hosted zone ID of the CloudFront distribution.    |

--- a/modules/ci-iam-policy/README.md
+++ b/modules/ci-iam-policy/README.md
@@ -1,0 +1,61 @@
+# IAM policy for CI/CD pipelines
+
+### Installation and usage
+
+<!-- x-release-please-start-version -->
+
+```terraform
+module "ci_iam_policy" {
+  source  = "unfunco/static-website/aws//modules/ci-iam-policy"
+  version = "0.3.0"
+
+  attach_content_permissions  = true
+  bucket_name                 = "unfun.co"
+}
+```
+
+<!-- x-release-please-end -->
+
+<!-- BEGIN_TF_DOCS -->
+
+### Resources
+
+| Name                                                                                                                                         | Type        |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)       | data source |
+| [aws_iam_policy_document.content](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)        | data source |
+| [aws_iam_policy_document.infrastructure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition)                               | data source |
+
+### Inputs
+
+| Name                              | Description                                                                                                         | Type          | Default | Required |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------- | ------- | :------: |
+| attach_content_permissions        | Whether to attach permissions for deploying content to the S3 bucket.                                               | `bool`        | `true`  |    no    |
+| attach_infrastructure_permissions | Whether to attach permissions for managing the underlying infrastructure.                                           | `bool`        | `false` |    no    |
+| bucket_name                       | The name of the S3 bucket for the static website.                                                                   | `string`      | n/a     |   yes    |
+| cloudfront_distribution_arn       | The ARN of the CloudFront distribution for scoping cache invalidation permissions.                                  | `string`      | `"*"`   |    no    |
+| create                            | Whether to create resources.                                                                                        | `bool`        | `true`  |    no    |
+| required_resource_tags            | Required aws:ResourceTag conditions for content permissions. Keys are tag names and values are required tag values. | `map(string)` | `{}`    |    no    |
+
+### Outputs
+
+| Name            | Description                                                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| policy_document | The JSON-encoded IAM policy document. Can be passed to iam_role_inline_policies in the unfunco/oidc-github module. |
+
+<!-- END_TF_DOCS -->
+
+## License
+
+© 2026 [Daniel Morris]\
+Made available under the terms of the [MIT License].
+
+[aws]: https://aws.amazon.com
+[aws provider]: https://registry.terraform.io/providers/hashicorp/aws
+[cloudfront]: https://aws.amazon.com/cloudfront
+[daniel morris]: https://unfun.co
+[mit license]: ../../LICENSE.md
+[origin access control]: https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-introduces-origin-access-control-oac/
+[s3]: https://aws.amazon.com/s3
+[terraform]: https://terraform.io

--- a/modules/ci-iam-policy/data.tf
+++ b/modules/ci-iam-policy/data.tf
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2026 Daniel Morris <daniel@honestempire.com>
+// SPDX-License-Identifier: MIT
+
+data "aws_partition" "this" {
+  count = var.create ? 1 : 0
+}
+
+data "aws_iam_policy_document" "content" {
+  count = var.create && var.attach_content_permissions ? 1 : 0
+
+  statement {
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+
+    effect = "Allow"
+    resources = [
+      format(
+        "arn:%s:s3:::%s",
+        data.aws_partition.this[0].partition,
+        var.bucket_name,
+      ),
+    ]
+
+    sid = "StaticWebsiteContentPermissionsS3Bucket"
+
+    dynamic "condition" {
+      for_each = var.required_resource_tags
+
+      content {
+        test     = "StringEquals"
+        values   = [condition.value]
+        variable = "aws:ResourceTag/${condition.key}"
+      }
+    }
+  }
+
+  statement {
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+
+    effect = "Allow"
+    resources = [
+      format(
+        "arn:%s:s3:::%s/*",
+        data.aws_partition.this[0].partition,
+        var.bucket_name,
+      ),
+    ]
+
+    sid = "StaticWebsiteContentPermissionsS3Object"
+  }
+
+  statement {
+    actions   = ["cloudfront:CreateInvalidation"]
+    effect    = "Allow"
+    resources = [var.cloudfront_distribution_arn]
+    sid       = "StaticWebsiteContentPermissionsCloudFront"
+
+    dynamic "condition" {
+      for_each = var.required_resource_tags
+
+      content {
+        test     = "StringEquals"
+        values   = [condition.value]
+        variable = "aws:ResourceTag/${condition.key}"
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "infrastructure" {
+  count = var.create && var.attach_infrastructure_permissions ? 1 : 0
+
+  statement {
+    actions = [
+      "acm:AddTagsToCertificate",
+      "acm:DeleteCertificate",
+      "acm:DescribeCertificate",
+      "acm:GetCertificate",
+      "acm:ListCertificates",
+      "acm:ListTagsForCertificate",
+      "acm:RemoveTagsFromCertificate",
+      "acm:RequestCertificate",
+    ]
+
+    effect    = "Allow"
+    resources = ["*"]
+    sid       = "StaticWebsiteInfrastructurePermissionsAcm"
+  }
+
+  statement {
+    actions = [
+      "cloudfront:CreateDistribution",
+      "cloudfront:DeleteDistribution",
+      "cloudfront:GetDistribution",
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:ListTagsForResource",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource",
+      "cloudfront:UpdateDistribution",
+    ]
+
+    effect    = "Allow"
+    resources = ["*"]
+    sid       = "StaticWebsiteInfrastructurePermissionsCloudFront"
+  }
+
+  statement {
+    actions = [
+      "cloudfront:CreateOriginAccessControl",
+      "cloudfront:DeleteOriginAccessControl",
+      "cloudfront:GetOriginAccessControl",
+      "cloudfront:GetOriginAccessControlConfig",
+      "cloudfront:ListOriginAccessControls",
+      "cloudfront:UpdateOriginAccessControl",
+    ]
+
+    effect    = "Allow"
+    resources = ["*"]
+    sid       = "StaticWebsiteInfrastructurePermissionsCloudFrontOac"
+  }
+
+  statement {
+    actions = [
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:DeleteBucketOwnershipControls",
+      "s3:DeleteBucketPolicy",
+      "s3:DeleteBucketPublicAccessBlock",
+      "s3:GetBucketLocation",
+      "s3:GetBucketLogging",
+      "s3:GetBucketOwnershipControls",
+      "s3:GetBucketPolicy",
+      "s3:GetBucketPublicAccessBlock",
+      "s3:GetBucketTagging",
+      "s3:GetBucketVersioning",
+      "s3:GetLifecycleConfiguration",
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:PutBucketLogging",
+      "s3:PutBucketOwnershipControls",
+      "s3:PutBucketPolicy",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:PutBucketTagging",
+      "s3:PutBucketVersioning",
+      "s3:PutLifecycleConfiguration",
+    ]
+
+    effect = "Allow"
+    resources = [
+      format(
+        "arn:%s:s3:::%s",
+        data.aws_partition.this[0].partition,
+        var.bucket_name,
+      ),
+    ]
+
+    sid = "StaticWebsiteInfrastructurePermissionsS3"
+  }
+
+  statement {
+    actions = [
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+    ]
+
+    effect = "Allow"
+    resources = [
+      format(
+        "arn:%s:s3:::%s/*",
+        data.aws_partition.this[0].partition,
+        var.bucket_name,
+      ),
+    ]
+
+    sid = "StaticWebsiteInfrastructurePermissionsS3Object"
+  }
+
+  statement {
+    actions   = ["s3:ListAllMyBuckets"]
+    effect    = "Allow"
+    resources = ["*"]
+    sid       = "StaticWebsiteInfrastructurePermissionsS3Global"
+  }
+}
+
+data "aws_iam_policy_document" "combined" {
+  count = var.create ? 1 : 0
+
+  source_policy_documents = compact([
+    var.attach_content_permissions ? data.aws_iam_policy_document.content[0].json : "",
+    var.attach_infrastructure_permissions ? data.aws_iam_policy_document.infrastructure[0].json : "",
+  ])
+}

--- a/modules/ci-iam-policy/outputs.tf
+++ b/modules/ci-iam-policy/outputs.tf
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Daniel Morris <daniel@honestempire.com>
+// SPDX-License-Identifier: MIT
+
+output "policy_document" {
+  description = "The JSON-encoded IAM policy document. Can be passed to iam_role_inline_policies in the unfunco/oidc-github module."
+  value       = var.create ? data.aws_iam_policy_document.combined[0].json : ""
+}

--- a/modules/ci-iam-policy/variables.tf
+++ b/modules/ci-iam-policy/variables.tf
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Daniel Morris <daniel@honestempire.com>
+// SPDX-License-Identifier: MIT
+
+variable "attach_content_permissions" {
+  default     = true
+  description = "Whether to attach permissions for deploying content to the S3 bucket."
+  type        = bool
+}
+
+variable "attach_infrastructure_permissions" {
+  default     = false
+  description = "Whether to attach permissions for managing the underlying infrastructure."
+  type        = bool
+}
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket for the static website."
+  type        = string
+}
+
+variable "cloudfront_distribution_arn" {
+  default     = "*"
+  description = "The ARN of the CloudFront distribution for scoping cache invalidation permissions."
+  type        = string
+}
+
+variable "create" {
+  default     = true
+  description = "Whether to create resources."
+  type        = bool
+}
+
+variable "required_resource_tags" {
+  default     = {}
+  description = "Required aws:ResourceTag conditions for content permissions. Keys are tag names and values are required tag values."
+  type        = map(string)
+}

--- a/modules/ci-iam-policy/versions.tf
+++ b/modules/ci-iam-policy/versions.tf
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Daniel Morris <daniel@honestempire.com>
+// SPDX-License-Identifier: MIT
+
+terraform {
+  required_version = "~> 1.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,6 +11,11 @@ output "bucket_id" {
   value       = try(aws_s3_bucket.this[0].id, "")
 }
 
+output "bucket_name" {
+  description = "The name of the S3 bucket."
+  value       = try(aws_s3_bucket.this[0].id, "")
+}
+
 output "certificate_arn" {
   description = "The ARN of the ACM certificate."
   value       = try(aws_acm_certificate.this[0].arn, "")
@@ -24,6 +29,11 @@ output "certificate_domain_validation_options" {
 output "cloudfront_distribution_id" {
   description = "The CloudFront distribution ID."
   value       = try(aws_cloudfront_distribution.this[0].id, "")
+}
+
+output "cloudfront_distribution_arn" {
+  description = "The ARN of the CloudFront distribution."
+  value       = try(aws_cloudfront_distribution.this[0].arn, "")
 }
 
 output "cloudfront_domain_name" {

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Daniel Morris <daniel@honestempire.com>
+// SPDX-License-Identifier: MIT
+
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"


### PR DESCRIPTION
Adds a submodule that can be used to generate an IAM policy that can be attached to an IAM role, e.g. one created by the unfunco/oidc-github Terraform module, the submodule has two modes that allow the permissions required to manage the infrastructure, and the permissions required to deploy objects to the S3 bucket can be included in the IAM policy.